### PR TITLE
chore: update REPO_NAME to eda

### DIFF
--- a/docs/docsite/links.yml
+++ b/docs/docsite/links.yml
@@ -4,12 +4,12 @@
 # Remove this section if the collection repository is not on GitHub, or if you do not want this
 # functionality for your collection.
 edit_on_github:
-  repository: ansible-collections/community.REPO_NAME
+  repository: ansible-collections/community.eda
   branch: main
   # If your collection root (the directory containing galaxy.yml) does not coincide with your
   # repository's root, you have to specify the path to the collection root here. For example,
-  # if the collection root is in a subdirectory ansible_collections/community/REPO_NAME
-  # in your repository, you have to set path_prefix to 'ansible_collections/community/REPO_NAME'.
+  # if the collection root is in a subdirectory ansible_collections/community/eda
+  # in your repository, you have to set path_prefix to 'ansible_collections/community/eda'.
   path_prefix: ''
 
 # Here you can add arbitrary extra links. Please keep the number of links down to a
@@ -25,7 +25,7 @@ edit_on_github:
 
 extra_links:
   - description: Report an issue
-    url: https://github.com/ansible-collections/community.REPO_NAME/issues/new/choose
+    url: https://github.com/ansible-collections/community.eda/issues/new/choose
 
 # Specify communication channels for your collection. We suggest to not specify more
 # than one place for communication per communication tool to avoid confusion.

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -2,22 +2,24 @@
 # See https://docs.ansible.com/ansible/latest/dev_guide/collections_galaxy_meta.html
 
 namespace: community
-name: FIXME
+name: eda
 version: 0.1.0
 readme: README.md
 authors:
-  - YOUR NAME (github.com/YOURGITHUB)
+  - John Barker (github.com/gundalow)
+  - Doston Toirov (github.com/Dostonbek1)
 description: null
 license_file: LICENSE
 tags:
 # tags so people can search for collections https://galaxy.ansible.com/search
 # tags are all lower-case, no spaces, no dashes.
-  - example1
-  - example2
-repository: https://github.com/ansible-collections/community.REPO_NAME
-#documentation: https://github.com/ansible-collection-migration/community.REPO_NAME/tree/main/docs
-homepage: https://github.com/ansible-collections/community.REPO_NAME
-issues: https://github.com/ansible-collections/community.REPO_NAME/issues
+  - infrastructure
+  - tools
+  - eda
+repository: https://github.com/ansible-collections/community.eda
+#documentation: https://github.com/ansible-collection-migration/community.eda/tree/main/docs
+homepage: https://github.com/ansible-collections/community.eda
+issues: https://github.com/ansible-collections/community.eda/issues
 build_ignore:
 # https://docs.ansible.com/ansible/devel/dev_guide/developing_collections_distributing.html#ignoring-files-and-folders
   - .gitignore


### PR DESCRIPTION
##### SUMMARY
This changes the template placeholder `REPO_NAME` to `eda` in order to fix the currently failing [CI check](https://github.com/ansible-collections/community.eda/actions/runs/13702143016/job/38318422872). 
