### PR TITLE
Few CI fixes

### DIFF
--- a/.config/dictionary.txt
+++ b/.config/dictionary.txt
@@ -31,6 +31,7 @@ confluentinc
 conftest
 conninfo
 containerd
+cooldown
 darglint
 dbname
 deadsnakes

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -36,7 +36,7 @@ jobs:
     steps:
       - name: Determine matrix
         id: generate_matrix
-        uses: coactions/dynamic-matrix@main # v3
+        uses: ansible/actions/matrix@v0
         with:
           min_python: "3.11"
           max_python: "3.12"


### PR DESCRIPTION
- use non-archived GitHub matrix action
- exclude from spell checking a word used in the dependabot configuration

This hopefully fixes all the CI jobs.

Check the message of each commit for longer explanations.